### PR TITLE
# 40 custom annotation, custom entity 패키지 구조 변경

### DIFF
--- a/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
@@ -43,16 +43,15 @@ class GAuthSignInUseCase(
 
         val student = queryStudentPort.queryStudentByUser(user) ?: throw StudentNotFoundException()
 
-        when (user.authority) {
-            Authority.ROLE_STUDENT -> return jwtGeneratorPort.receiveToken(student.id, user.authority)
-            Authority.ROLE_TEACHER -> return jwtGeneratorPort.receiveToken(user.id, user.authority)
+        return when (user.authority) {
+            Authority.ROLE_STUDENT -> jwtGeneratorPort.receiveToken(student.id, user.authority)
+            Authority.ROLE_TEACHER -> jwtGeneratorPort.receiveToken(user.id, user.authority)
         }
     }
 
-    private fun createUser(user: User): User {
-        return when (userPort.queryExistByEmail(user.email)) {
+    private fun createUser(user: User): User =
+        when (userPort.queryExistByEmail(user.email)) {
             true -> userPort.queryUserByEmail(user.email) ?: throw UserNotFoundException()
             false -> userPort.save(user)
         }
-    }
 }

--- a/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
@@ -9,7 +9,7 @@ import com.stack.knowledege.domain.user.application.spi.UserPort
 import com.stack.knowledege.domain.user.domain.User
 import com.stack.knowledege.domain.user.domain.constant.Authority
 import com.stack.knowledege.domain.user.exception.UserNotFoundException
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import com.stack.knowledege.global.security.spi.JwtGeneratorPort
 import com.stack.knowledege.thirdparty.gauth.spi.GAuthPort
 import java.util.*

--- a/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/ReissueTokenUseCase.kt
@@ -6,7 +6,7 @@ import com.stack.knowledege.domain.auth.exception.RefreshTokenNotFoundException
 import com.stack.knowledege.domain.auth.presentation.data.response.TokenResponse
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.exception.UserNotFoundException
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import com.stack.knowledege.global.security.spi.JwtGeneratorPort
 import com.stack.knowledege.global.security.spi.JwtParserPort
 

--- a/src/main/kotlin/com/stack/knowledege/domain/auth/domain/RefreshToken.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/domain/RefreshToken.kt
@@ -1,6 +1,6 @@
 package com.stack.knowledege.domain.auth.domain
 
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.UUID
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/common/annotation/Aggregate.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/annotation/Aggregate.kt
@@ -1,4 +1,4 @@
-package com.stack.knowledege.global.annotation
+package com.stack.knowledege.domain.common.annotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/com/stack/knowledege/domain/common/annotation/usecase/ReadOnlyUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/annotation/usecase/ReadOnlyUseCase.kt
@@ -1,4 +1,4 @@
-package com.stack.knowledege.global.annotation.usecase
+package com.stack.knowledege.domain.common.annotation.usecase
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/stack/knowledege/domain/common/annotation/usecase/UseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/annotation/usecase/UseCase.kt
@@ -1,4 +1,4 @@
-package com.stack.knowledege.global.annotation.usecase
+package com.stack.knowledege.domain.common.annotation.usecase
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseIdEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseIdEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.MappedSuperclass
 @MappedSuperclass
 abstract class BaseIdEntity(
     @Id
-//    @GeneratedValue(generator = "uuid2")
+    @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     open val id: UUID

--- a/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseIdEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseIdEntity.kt
@@ -1,4 +1,4 @@
-package com.stack.knowledege.global.entity
+package com.stack.knowledege.domain.common.entity
 
 import org.hibernate.annotations.GenericGenerator
 import java.util.UUID

--- a/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/common/entity/BaseTimeEntity.kt
@@ -1,4 +1,4 @@
-package com.stack.knowledege.global.entity
+package com.stack.knowledege.domain.common.entity
 
 import java.time.LocalDateTime
 import javax.persistence.Column

--- a/src/main/kotlin/com/stack/knowledege/domain/image/application/usecase/UpdateImageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/image/application/usecase/UpdateImageUseCase.kt
@@ -3,7 +3,7 @@ package com.stack.knowledege.domain.image.application.usecase
 import com.stack.knowledege.domain.image.application.spi.CommandImagePort
 import com.stack.knowledege.domain.image.application.validator.ImageValidator
 import com.stack.knowledege.domain.user.application.spi.UserPort
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/image/application/usecase/UploadImageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/image/application/usecase/UploadImageUseCase.kt
@@ -4,7 +4,7 @@ import com.stack.knowledege.domain.image.application.spi.CommandImagePort
 import com.stack.knowledege.domain.image.application.validator.ImageValidator
 import com.stack.knowledege.domain.image.exception.ProfileImageAlreadyExist
 import com.stack.knowledege.domain.user.application.spi.UserPort
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import org.springframework.web.multipart.MultipartFile
 import java.util.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/item/application/usecase/QueryAllItemUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/item/application/usecase/QueryAllItemUseCase.kt
@@ -2,7 +2,7 @@ package com.stack.knowledege.domain.item.application.usecase
 
 import com.stack.knowledege.domain.item.application.spi.QueryItemPort
 import com.stack.knowledege.domain.item.presentation.data.response.ItemResponse
-import com.stack.knowledege.global.annotation.usecase.ReadOnlyUseCase
+import com.stack.knowledege.domain.common.annotation.usecase.ReadOnlyUseCase
 
 @ReadOnlyUseCase
 class QueryAllItemUseCase(

--- a/src/main/kotlin/com/stack/knowledege/domain/item/domain/Item.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/item/domain/Item.kt
@@ -1,6 +1,6 @@
 package com.stack.knowledege.domain.item.domain
 
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.*
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/item/persistence/entity/ItemJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/item/persistence/entity/ItemJpaEntity.kt
@@ -1,6 +1,6 @@
 package com.stack.knowledege.domain.item.persistence.entity
 
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity

--- a/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/CreateMissionUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/CreateMissionUseCase.kt
@@ -6,7 +6,7 @@ import com.stack.knowledege.domain.mission.domain.constant.MissionStatus
 import com.stack.knowledege.domain.mission.presentation.data.request.CreateMissionRequest
 import com.stack.knowledege.domain.user.application.spi.UserPort
 import com.stack.knowledege.domain.user.application.validator.UserValidator
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import java.time.LocalTime
 import java.util.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/QueryAllMissionUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/QueryAllMissionUseCase.kt
@@ -5,7 +5,7 @@ import com.stack.knowledege.domain.mission.presentation.data.response.MissionRes
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.exception.UserNotFoundException
 import com.stack.knowledege.domain.user.presentation.data.response.UserResponse
-import com.stack.knowledege.global.annotation.usecase.ReadOnlyUseCase
+import com.stack.knowledege.domain.common.annotation.usecase.ReadOnlyUseCase
 
 @ReadOnlyUseCase
 class QueryAllMissionUseCase(

--- a/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/QueryMissionDetailsUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/mission/application/usecase/QueryMissionDetailsUseCase.kt
@@ -3,7 +3,7 @@ package com.stack.knowledege.domain.mission.application.usecase
 import com.stack.knowledege.domain.mission.application.spi.MissionPort
 import com.stack.knowledege.domain.mission.exception.MissionNotFoundException
 import com.stack.knowledege.domain.mission.presentation.data.response.MissionDetailsResponse
-import com.stack.knowledege.global.annotation.usecase.ReadOnlyUseCase
+import com.stack.knowledege.domain.common.annotation.usecase.ReadOnlyUseCase
 import java.util.UUID
 
 @ReadOnlyUseCase

--- a/src/main/kotlin/com/stack/knowledege/domain/mission/domain/Mission.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/mission/domain/Mission.kt
@@ -1,7 +1,7 @@
 package com.stack.knowledege.domain.mission.domain
 
 import com.stack.knowledege.domain.mission.domain.constant.MissionStatus
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.UUID
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/mission/persistence/entity/MissionJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/mission/persistence/entity/MissionJpaEntity.kt
@@ -2,7 +2,7 @@ package com.stack.knowledege.domain.mission.persistence.entity
 
 import com.stack.knowledege.domain.mission.domain.constant.MissionStatus
 import com.stack.knowledege.domain.user.persistence.entity.UserJpaEntity
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.*
 import javax.persistence.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/order/application/usecase/OrderItemUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/order/application/usecase/OrderItemUseCase.kt
@@ -10,7 +10,7 @@ import com.stack.knowledege.domain.order.presentation.data.request.OrderItemRequ
 import com.stack.knowledege.domain.student.application.spi.QueryStudentPort
 import com.stack.knowledege.domain.student.exception.StudentNotFoundException
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import java.util.UUID
 
 @UseCase

--- a/src/main/kotlin/com/stack/knowledege/domain/order/application/usecase/QueryAllIsOrderedItemUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/order/application/usecase/QueryAllIsOrderedItemUseCase.kt
@@ -11,7 +11,7 @@ import com.stack.knowledege.domain.student.exception.StudentNotFoundException
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.exception.UserNotFoundException
 import com.stack.knowledege.domain.user.presentation.data.response.UserResponse
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 
 @UseCase
 class QueryAllIsOrderedItemUseCase(

--- a/src/main/kotlin/com/stack/knowledege/domain/order/persistence/entity/OrderJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/order/persistence/entity/OrderJpaEntity.kt
@@ -3,7 +3,7 @@ package com.stack.knowledege.domain.order.persistence.entity
 import com.stack.knowledege.domain.item.persistence.entity.ItemJpaEntity
 import com.stack.knowledege.domain.order.domain.constant.OrderStatus
 import com.stack.knowledege.domain.student.persistence.entity.StudentJpaEntity
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.UUID
 import javax.persistence.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/solve/application/usecase/SolveMissionUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/solve/application/usecase/SolveMissionUseCase.kt
@@ -13,7 +13,7 @@ import com.stack.knowledege.domain.student.application.spi.QueryStudentPort
 import com.stack.knowledege.domain.student.exception.StudentNotFoundException
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.domain.constant.Authority
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import java.util.UUID
 
 @UseCase

--- a/src/main/kotlin/com/stack/knowledege/domain/solve/domain/Solve.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/solve/domain/Solve.kt
@@ -1,7 +1,7 @@
 package com.stack.knowledege.domain.solve.domain
 
 import com.stack.knowledege.domain.solve.domain.constant.SolveStatus
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.*
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/solve/persistence/entity/SolveJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/solve/persistence/entity/SolveJpaEntity.kt
@@ -3,7 +3,7 @@ package com.stack.knowledege.domain.solve.persistence.entity
 import com.stack.knowledege.domain.mission.persistence.entity.MissionJpaEntity
 import com.stack.knowledege.domain.solve.domain.constant.SolveStatus
 import com.stack.knowledege.domain.student.persistence.entity.StudentJpaEntity
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.*
 import javax.persistence.*
 

--- a/src/main/kotlin/com/stack/knowledege/domain/student/application/spi/CommandStudentPort.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/application/spi/CommandStudentPort.kt
@@ -3,5 +3,5 @@ package com.stack.knowledege.domain.student.application.spi
 import com.stack.knowledege.domain.student.domain.Student
 
 interface CommandStudentPort {
-    fun save(student: Student): Student
+    fun save(student: Student)
 }

--- a/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/CreateStudentUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/CreateStudentUseCase.kt
@@ -3,7 +3,7 @@ package com.stack.knowledege.domain.student.application.usecase
 import com.stack.knowledege.domain.student.application.spi.CommandStudentPort
 import com.stack.knowledege.domain.student.domain.Student
 import com.stack.knowledege.domain.user.domain.User
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import java.util.*
 
 @UseCase

--- a/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/CreateStudentUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/CreateStudentUseCase.kt
@@ -10,7 +10,7 @@ import java.util.*
 class CreateStudentUseCase(
     private val commandStudentPort: CommandStudentPort
 ) {
-    fun execute(user: User): Student {
+    fun execute(user: User) {
         val student = Student(
             id = UUID.randomUUID(),
             currentPoint = 0,
@@ -18,6 +18,6 @@ class CreateStudentUseCase(
             user = user.id
         )
 
-        return commandStudentPort.save(student)
+        commandStudentPort.save(student)
     }
 }

--- a/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/QueryAllStudentsRankingUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/application/usecase/QueryAllStudentsRankingUseCase.kt
@@ -4,7 +4,7 @@ import com.stack.knowledege.domain.student.application.spi.QueryStudentPort
 import com.stack.knowledege.domain.student.presentation.data.response.AllStudentsRankingResponse
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.presentation.data.response.UserResponse
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 
 @UseCase
 class QueryAllStudentsRankingUseCase(

--- a/src/main/kotlin/com/stack/knowledege/domain/student/domain/Student.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/domain/Student.kt
@@ -1,6 +1,6 @@
 package com.stack.knowledege.domain.student.domain
 
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.*
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/student/persistence/StudentPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/persistence/StudentPersistenceAdapter.kt
@@ -17,8 +17,9 @@ class StudentPersistenceAdapter(
     private val userMapper: UserMapper
 ) : StudentPort {
 
-    override fun save(student: Student): Student =
-        studentMapper.toDomain(studentJpaRepository.save(studentMapper.toEntity(student)))!!
+    override fun save(student: Student) {
+        studentJpaRepository.save(studentMapper.toEntity(student))
+    }
 
     override fun queryStudentById(id: UUID): Student? =
         studentMapper.toDomain(studentJpaRepository.findByIdOrNull(id))

--- a/src/main/kotlin/com/stack/knowledege/domain/student/persistence/entity/StudentJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/student/persistence/entity/StudentJpaEntity.kt
@@ -1,7 +1,7 @@
 package com.stack.knowledege.domain.student.persistence.entity
 
 import com.stack.knowledege.domain.user.persistence.entity.UserJpaEntity
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity

--- a/src/main/kotlin/com/stack/knowledege/domain/user/application/usecase/QueryScoringPageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/user/application/usecase/QueryScoringPageUseCase.kt
@@ -2,7 +2,7 @@ package com.stack.knowledege.domain.user.application.usecase
 
 import com.stack.knowledege.domain.solve.application.spi.QuerySolvePort
 import com.stack.knowledege.domain.user.presentation.data.response.AllScoringResponse
-import com.stack.knowledege.global.annotation.usecase.ReadOnlyUseCase
+import com.stack.knowledege.domain.common.annotation.usecase.ReadOnlyUseCase
 
 @ReadOnlyUseCase
 class QueryScoringPageUseCase(

--- a/src/main/kotlin/com/stack/knowledege/domain/user/application/usecase/ScoreSolveUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/user/application/usecase/ScoreSolveUseCase.kt
@@ -14,7 +14,7 @@ import com.stack.knowledege.domain.student.exception.StudentNotFoundException
 import com.stack.knowledege.domain.user.application.spi.QueryUserPort
 import com.stack.knowledege.domain.user.domain.constant.Authority
 import com.stack.knowledege.domain.user.presentation.data.request.ScoreSolveRequest
-import com.stack.knowledege.global.annotation.usecase.UseCase
+import com.stack.knowledege.domain.common.annotation.usecase.UseCase
 import java.util.UUID
 
 @UseCase

--- a/src/main/kotlin/com/stack/knowledege/domain/user/domain/User.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/user/domain/User.kt
@@ -1,7 +1,7 @@
 package com.stack.knowledege.domain.user.domain
 
 import com.stack.knowledege.domain.user.domain.constant.Authority
-import com.stack.knowledege.global.annotation.Aggregate
+import com.stack.knowledege.domain.common.annotation.Aggregate
 import java.util.*
 
 @Aggregate

--- a/src/main/kotlin/com/stack/knowledege/domain/user/persistence/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/user/persistence/entity/UserJpaEntity.kt
@@ -1,7 +1,7 @@
 package com.stack.knowledege.domain.user.persistence.entity
 
 import com.stack.knowledege.domain.user.domain.constant.Authority
-import com.stack.knowledege.global.entity.BaseIdEntity
+import com.stack.knowledege.domain.common.entity.BaseIdEntity
 import java.util.*
 import javax.persistence.*
 


### PR DESCRIPTION
## 💡 개요
custom annotation, custom entity 패키지 구조 변경
## 📃 작업내용
custom annotation, custom entity은 global 에서 처리할 작업이 아니라고 느끼고 domain-entity 패키지로 변경하였습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
