### PR TITLE
# 44 토큰 재발급 url 을 permitAll로 설정

### DIFF
--- a/src/main/kotlin/com/stack/knowledege/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/stack/knowledege/global/security/SecurityConfig.kt
@@ -43,7 +43,7 @@ class SecurityConfig(
 
             // auth
             .antMatchers(HttpMethod.POST, "/auth").permitAll()
-            .antMatchers(HttpMethod.PATCH, "/auth").authenticated()
+            .antMatchers(HttpMethod.PATCH, "/auth").permitAll()
 
             // item
             .antMatchers(HttpMethod.GET , "/item").hasRole(student)


### PR DESCRIPTION
## 💡 개요
토큰 재발급 url 을 permitAll로 설정
## 📃 작업내용
토큰 재발급 url 을 permitAll로 설정해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
