### PR TITLE
# 52 토큰 재발급 오류 수정

### DIFF
--- a/src/main/kotlin/com/stack/knowledege/common/service/SecurityService.kt
+++ b/src/main/kotlin/com/stack/knowledege/common/service/SecurityService.kt
@@ -4,4 +4,5 @@ import com.stack.knowledege.domain.user.domain.User
 
 interface SecurityService {
     fun queryCurrentUser(): User
+    fun queryCurrentUserAuthority(): String
 }

--- a/src/main/kotlin/com/stack/knowledege/common/service/impl/SecurityServiceImpl.kt
+++ b/src/main/kotlin/com/stack/knowledege/common/service/impl/SecurityServiceImpl.kt
@@ -27,4 +27,7 @@ class SecurityServiceImpl(
             }
             else -> throw InvalidRoleException()
         }
+
+    override fun queryCurrentUserAuthority(): String =
+        securityPort.queryCurrentUserAuthority()
 }

--- a/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/GAuthSignInUseCase.kt
@@ -41,10 +41,11 @@ class GAuthSignInUseCase(
             createStudentUseCase.execute(user)
 
         val student = queryStudentPort.queryStudentByUser(user) ?: throw StudentNotFoundException()
+        println(student.id)
 
         return when (user.authority) {
-            Authority.ROLE_STUDENT -> jwtGeneratorPort.receiveToken(student.id, user.authority)
-            Authority.ROLE_TEACHER -> jwtGeneratorPort.receiveToken(user.id, user.authority)
+            Authority.ROLE_STUDENT -> jwtGeneratorPort.receiveToken(student.id, user.authority.name)
+            Authority.ROLE_TEACHER -> jwtGeneratorPort.receiveToken(user.id, user.authority.name)
         }
     }
 

--- a/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledege/domain/auth/application/usecase/ReissueTokenUseCase.kt
@@ -4,9 +4,8 @@ import com.stack.knowledege.domain.auth.application.spi.QueryRefreshTokenPort
 import com.stack.knowledege.domain.auth.exception.InvalidRefreshTokenException
 import com.stack.knowledege.domain.auth.exception.RefreshTokenNotFoundException
 import com.stack.knowledege.domain.auth.presentation.data.response.TokenResponse
-import com.stack.knowledege.domain.user.application.spi.QueryUserPort
-import com.stack.knowledege.domain.user.exception.UserNotFoundException
 import com.stack.knowledege.common.annotation.usecase.UseCase
+import com.stack.knowledege.common.service.SecurityService
 import com.stack.knowledege.global.security.spi.JwtGeneratorPort
 import com.stack.knowledege.global.security.spi.JwtParserPort
 
@@ -15,13 +14,13 @@ class ReissueTokenUseCase(
     private val jwtParserPort: JwtParserPort,
     private val jwtGeneratorPort: JwtGeneratorPort,
     private val queryRefreshTokenPort: QueryRefreshTokenPort,
-    private val queryUserPort: QueryUserPort
+    private val securityService: SecurityService
 ) {
     fun execute(requestToken: String): TokenResponse {
         val refreshToken = jwtParserPort.parseRefreshToken(requestToken) ?: throw InvalidRefreshTokenException()
         val token = queryRefreshTokenPort.queryByRefreshToken(refreshToken) ?: throw RefreshTokenNotFoundException()
-        val user = queryUserPort.queryUserById(token.userId) ?: throw UserNotFoundException()
+        val authority = securityService.queryCurrentUserAuthority()
 
-        return jwtGeneratorPort.receiveToken(token.userId, user.authority)
+        return jwtGeneratorPort.receiveToken(token.userId, authority)
     }
 }

--- a/src/main/kotlin/com/stack/knowledege/global/security/spi/JwtGeneratorPort.kt
+++ b/src/main/kotlin/com/stack/knowledege/global/security/spi/JwtGeneratorPort.kt
@@ -1,9 +1,8 @@
 package com.stack.knowledege.global.security.spi
 
 import com.stack.knowledege.domain.auth.presentation.data.response.TokenResponse
-import com.stack.knowledege.domain.user.domain.constant.Authority
 import java.util.UUID
 
 interface JwtGeneratorPort {
-    fun receiveToken(userId: UUID, authority: Authority): TokenResponse
+    fun receiveToken(userId: UUID, authority: String): TokenResponse
 }

--- a/src/main/kotlin/com/stack/knowledege/global/security/token/JwtGeneratorAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledege/global/security/token/JwtGeneratorAdapter.kt
@@ -3,7 +3,6 @@ package com.stack.knowledege.global.security.token
 import com.stack.knowledege.domain.auth.application.spi.CommandRefreshTokenPort
 import com.stack.knowledege.domain.auth.domain.RefreshToken
 import com.stack.knowledege.domain.auth.presentation.data.response.TokenResponse
-import com.stack.knowledege.domain.user.domain.constant.Authority
 import com.stack.knowledege.global.security.spi.JwtGeneratorPort
 import com.stack.knowledege.global.security.token.properties.JwtProperties
 import io.jsonwebtoken.Jwts
@@ -18,7 +17,7 @@ class JwtGeneratorAdapter(
     private val commandRefreshTokenPort: CommandRefreshTokenPort
 ) : JwtGeneratorPort {
 
-    override fun receiveToken(userId: UUID, authority: Authority): TokenResponse {
+    override fun receiveToken(userId: UUID, authority: String): TokenResponse {
         val refreshToken = generateRefreshToken(userId)
         commandRefreshTokenPort.saveRefreshToken(RefreshToken(refreshToken, userId, jwtProperties.refreshExp))
         return TokenResponse(
@@ -28,12 +27,12 @@ class JwtGeneratorAdapter(
         )
     }
 
-    private fun generateAccessToken(userId: UUID, authority: Authority): String =
+    private fun generateAccessToken(userId: UUID, authority: String): String =
         Jwts.builder()
             .signWith(jwtProperties.accessSecret, SignatureAlgorithm.HS256)
             .setSubject(userId.toString())
             .claim("type", "access")
-            .claim("authority", authority.name)
+            .claim("authority", authority)
             .setIssuedAt(Date())
             .setExpiration(Date(System.currentTimeMillis() + jwtProperties.accessExp * 1000))
             .compact()


### PR DESCRIPTION
## 💡 개요
토큰 재발급 오류 수정
## 📃 작업내용
토큰 재발급 로직에서 user 를 query 하는 부분에서 만약 student 라면 user를 query 하지 못하는 오류가 발생해 수정했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
