### PR TITLE
# 69 mission 제목 및 내용 최대 글자 길이 설정

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/mission/presentation/data/request/CreateMissionRequest.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/presentation/data/request/CreateMissionRequest.kt
@@ -1,11 +1,14 @@
 package com.stack.knowledge.domain.mission.presentation.data.request
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class CreateMissionRequest(
     @field:NotBlank
+    @field:Size(max = 50)
     val title: String,
     @field:NotBlank
+    @field:Size(max = 500)
     val content: String,
     val timeLimit: Int
 )


### PR DESCRIPTION
## 💡 개요
mission 제목 및 내용 최대 글자 길이 설정
## 📃 작업내용
mission 제목 및 내용의 최대 글자 길이 설정을 해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
