### PR TITLE
# 72 TokenResponse에 role 추가

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/auth/presentation/data/response/TokenResponse.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/presentation/data/response/TokenResponse.kt
@@ -1,11 +1,13 @@
 package com.stack.knowledge.domain.auth.presentation.data.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.stack.knowledge.domain.user.domain.constant.Authority
 import java.time.ZonedDateTime
 
 data class TokenResponse (
     val accessToken: String,
     val refreshToken: String,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
-    val expiredAt: ZonedDateTime
+    val expiredAt: ZonedDateTime,
+    val authority: Authority
 )

--- a/src/main/kotlin/com/stack/knowledge/global/security/token/JwtGeneratorAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/security/token/JwtGeneratorAdapter.kt
@@ -24,7 +24,8 @@ class JwtGeneratorAdapter(
         return TokenResponse(
             accessToken = generateAccessToken(userId, authority),
             refreshToken = refreshToken,
-            expiredAt = getAccessTokenExpiredAt()
+            expiredAt = getAccessTokenExpiredAt(),
+            authority = authority
         )
     }
 


### PR DESCRIPTION
## 💡 개요
TokenResponse에 role 추가
## 📃 작업내용
어드민 페이지와 클라이언트 페이지의 차이점 때문에 GAuth 로그인 후에 반환해주는 TokenResponse에 Role을 추가해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
