### PR TITLE
# 96 Query String 필요없게 변경

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/image/application/usecase/UploadImageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/image/application/usecase/UploadImageUseCase.kt
@@ -16,17 +16,17 @@ class UploadImageUseCase(
     private val imageValidator: ImageValidator,
     private val securityService: SecurityService
 ) {
-    fun execute(multipartFile: MultipartFile): String {
+    fun execute(image: MultipartFile): String {
         val user = securityService.queryCurrentUser()
         val profileImage = user.profileImage ?: throw ProfileImageNotFoundException()
 
         if (profileImage != "")
             commandImagePort.deleteImageUrl(profileImage)
 
-        val fileName = imageValidator.validateImageExtension(multipartFile)
+        val fileName = imageValidator.validateImageExtension(image)
             .let { UUID.randomUUID().toString() + it }
 
         userPort.save(user.copy(profileImage = fileName))
-        return commandImagePort.upload(multipartFile, fileName)
+        return commandImagePort.upload(image, fileName)
     }
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/student/presentation/StudentWebAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/student/presentation/StudentWebAdapter.kt
@@ -27,7 +27,7 @@ class StudentWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @PostMapping("/image")
-    fun uploadImage(@RequestPart("image") multipartFile: MultipartFile): ResponseEntity<String> =
-        uploadImageUseCase.execute(multipartFile)
+    fun uploadImage(@RequestPart(value = "image", required = false) image: MultipartFile): ResponseEntity<String> =
+        uploadImageUseCase.execute(image)
             .let { ResponseEntity.ok(it) }
 }


### PR DESCRIPTION
## 💡 개요
Query String 필요없게 변경
## 📃 작업내용
Image 업로드 api에 요청할 때 `required = false` 로 변경해줌으로서 Query String 이 필요없게 변경해주었습니다.
또한 내부 로직에서 `multipartFile`이라는 이름으로 사용하던 인자를 `image`로 변경해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
