### PR TITLE
# 106 풀이 채점 api 오류 수정

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/point/application/spi/QueryPointPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/application/spi/QueryPointPort.kt
@@ -1,12 +1,10 @@
 package com.stack.knowledge.domain.point.application.spi
 
-import com.stack.knowledge.domain.mission.domain.Mission
 import com.stack.knowledge.domain.point.domain.Point
 import com.stack.knowledge.domain.solve.domain.Solve
 import java.util.*
 
 interface QueryPointPort {
-    fun queryPointByMission(mission: Mission): Point?
     fun queryPointBySolve(solve: Solve): Point?
     fun queryTopByMissionIdOrderByMissionPointDesc(missionId: UUID): Point?
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
@@ -1,7 +1,5 @@
 package com.stack.knowledge.domain.point.persistence
 
-import com.stack.knowledge.domain.mission.domain.Mission
-import com.stack.knowledge.domain.mission.persistence.mapper.MissionMapper
 import com.stack.knowledge.domain.point.application.spi.PointPort
 import com.stack.knowledge.domain.point.domain.Point
 import com.stack.knowledge.domain.point.persistence.mapper.PointMapper
@@ -15,15 +13,11 @@ import java.util.UUID
 class PointPersistenceAdapter(
     private val pointJpaRepository: PointJpaRepository,
     private val pointMapper: PointMapper,
-    private val missionMapper: MissionMapper,
     private val solveMapper: SolveMapper
 ) : PointPort {
     override fun save(point: Point) {
         pointJpaRepository.save(pointMapper.toEntity(point))
     }
-
-    override fun queryPointByMission(mission: Mission): Point? =
-        pointMapper.toDomain(pointJpaRepository.findByMission(missionMapper.toEntity(mission)))
 
     override fun queryPointBySolve(solve: Solve): Point? =
         pointMapper.toDomain(pointJpaRepository.findBySolve(solveMapper.toEntity(solve)))

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
@@ -1,13 +1,11 @@
 package com.stack.knowledge.domain.point.persistence.repository
 
-import com.stack.knowledge.domain.mission.persistence.entity.MissionJpaEntity
 import com.stack.knowledge.domain.point.persistence.entity.PointJpaEntity
 import com.stack.knowledge.domain.solve.persistence.entity.SolveJpaEntity
 import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
 interface PointJpaRepository : CrudRepository<PointJpaEntity, Long> {
-    fun findByMission(missionJpaEntity: MissionJpaEntity): PointJpaEntity
     fun findBySolve(solveJpaEntity: SolveJpaEntity): PointJpaEntity
     fun findTopByMissionIdOrderByMissionPointDesc(missionId: UUID): PointJpaEntity?
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/ScoreSolveUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/ScoreSolveUseCase.kt
@@ -30,7 +30,7 @@ class ScoreSolveUseCase(
         val solve = solvePort.querySolveById(solveId) ?: throw SolveNotFoundException()
         val student = queryStudentPort.queryStudentById(solve.student) ?: throw StudentNotFoundException()
         val mission = queryMissionPort.queryMissionById(solve.mission) ?: throw MissionNotFoundException()
-        val point = queryPointPort.queryPointByMission(mission) ?: throw PointNotFoundException()
+        val point = queryPointPort.queryPointBySolve(solve) ?: throw PointNotFoundException()
 
         if (solve.solveStatus != SolveStatus.SCORING)
             throw AlreadyScoredException()


### PR DESCRIPTION
## 💡 개요
풀이 채점 api 오류 수정
## 📃 작업내용
`Point` 도메인을 `queryByMission` 함수로 호출하면 List 로 Response 받아야 하는 문제가 발생해 1:1 관계인 `Solve` 도메인을 이용해 `queryBySolve` 로 대체하였습니다.