### PR TITLE
# 111 GAuth Admin 로그인 안되는 이슈 수정

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/GAuthSignInUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/GAuthSignInUseCase.kt
@@ -1,5 +1,7 @@
 package com.stack.knowledge.domain.auth.application.usecase
 
+import com.stack.knowledge.common.annotation.usecase.UseCase
+import com.stack.knowledge.domain.auth.application.spi.GAuthPort
 import com.stack.knowledge.domain.auth.presentation.data.request.GAuthSignInRequest
 import com.stack.knowledge.domain.auth.presentation.data.response.TokenResponse
 import com.stack.knowledge.domain.student.application.spi.QueryStudentPort
@@ -9,9 +11,7 @@ import com.stack.knowledge.domain.user.application.spi.UserPort
 import com.stack.knowledge.domain.user.domain.User
 import com.stack.knowledge.domain.user.domain.constant.Authority
 import com.stack.knowledge.domain.user.exception.UserNotFoundException
-import com.stack.knowledge.common.annotation.usecase.UseCase
 import com.stack.knowledge.global.security.spi.JwtGeneratorPort
-import com.stack.knowledge.domain.auth.application.spi.GAuthPort
 import java.util.*
 
 @UseCase
@@ -40,10 +40,11 @@ class GAuthSignInUseCase(
         if (!queryStudentPort.existStudentByUser(user) && user.authority == Authority.ROLE_STUDENT)
             createStudentUseCase.execute(user)
 
-        val student = queryStudentPort.queryStudentByUserId(user.id) ?: throw StudentNotFoundException()
-
         return when (user.authority) {
-            Authority.ROLE_STUDENT -> jwtGeneratorPort.receiveToken(student.id, user.authority)
+            Authority.ROLE_STUDENT -> {
+                val student = queryStudentPort.queryStudentByUserId(user.id) ?: throw StudentNotFoundException()
+                jwtGeneratorPort.receiveToken(student.id, user.authority)
+            }
             Authority.ROLE_TEACHER -> jwtGeneratorPort.receiveToken(user.id, user.authority)
         }
     }

--- a/src/main/kotlin/com/stack/knowledge/domain/order/presentation/data/response/IsOrderedOrderResponse.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/order/presentation/data/response/IsOrderedOrderResponse.kt
@@ -4,7 +4,7 @@ import com.stack.knowledge.domain.item.presentation.data.response.ItemResponse
 import com.stack.knowledge.domain.user.presentation.data.response.UserResponse
 import java.util.*
 
-class IsOrderedOrderResponse(
+data class IsOrderedOrderResponse(
     val id: UUID,
     val count: Int,
     val price: Int,

--- a/src/main/kotlin/com/stack/knowledge/domain/student/presentation/data/response/StudentPointResponse.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/student/presentation/data/response/StudentPointResponse.kt
@@ -3,7 +3,7 @@ package com.stack.knowledge.domain.student.presentation.data.response
 import com.stack.knowledge.domain.user.presentation.data.response.UserResponse
 import java.util.*
 
-class StudentPointResponse(
+data class StudentPointResponse(
     val id: UUID,
     val currentPoint: Int,
     val cumulatePoint: Int,

--- a/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageDetailsUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageDetailsUseCase.kt
@@ -6,7 +6,7 @@ import com.stack.knowledge.domain.mission.exception.MissionNotFoundException
 import com.stack.knowledge.domain.solve.application.spi.QuerySolvePort
 import com.stack.knowledge.domain.solve.exception.SolveNotFoundException
 import com.stack.knowledge.domain.user.presentation.data.response.ScoringDetailsResponse
-import java.util.UUID
+import java.util.*
 
 @ReadOnlyUseCase
 class QueryScoringPageDetailsUseCase(

--- a/src/main/kotlin/com/stack/knowledge/domain/user/domain/constant/Authority.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/domain/constant/Authority.kt
@@ -1,6 +1,5 @@
 package com.stack.knowledge.domain.user.domain.constant
 
 enum class Authority {
-
     ROLE_STUDENT, ROLE_TEACHER
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/user/presentation/data/request/ScoreSolveRequest.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/presentation/data/request/ScoreSolveRequest.kt
@@ -4,7 +4,7 @@ import com.stack.knowledge.domain.solve.domain.constant.SolveStatus
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 
-class ScoreSolveRequest(
+data class ScoreSolveRequest(
     @field:Enumerated(EnumType.STRING)
     val solveStatus: SolveStatus
 )

--- a/src/main/kotlin/com/stack/knowledge/domain/user/presentation/data/response/UserResponse.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/presentation/data/response/UserResponse.kt
@@ -2,7 +2,7 @@ package com.stack.knowledge.domain.user.presentation.data.response
 
 import java.util.UUID
 
-class UserResponse(
+data class UserResponse(
     val id: UUID,
     val email: String,
     val name: String,

--- a/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
@@ -75,7 +75,7 @@ class SecurityConfig(
 //            // solve
 //            .antMatchers(HttpMethod.POST, "/solve/{mission_id}").hasRole(student)
 
-            .anyRequest().permitAll()
+            .anyRequest().authenticated()
             .and()
 
             .exceptionHandling()


### PR DESCRIPTION
## 💡 개요
GAuth Admin 로그인 안되는 이슈 수정
## 📃 작업내용
Dto 를 data 클래스로 전부 맞추어 주었습니다.
ExceptionFilter의 try catch를 run catch로 수정해주었습니다.
admin의 경우 student를 조회하지 못하는 이슈를 해결하였습니다.
handle 하지 않는 url 에 요청을 보낼 경우 로그인을 해야하도록 변경해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
