### PR TITLE
# 113 채점할 문제 전체 조회 API 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,10 +53,6 @@ dependencies {
 
 	// test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("io.kotest:kotest-runner-junit5-jvm:4.4.3")
-	testImplementation("io.kotest:kotest-assertions-core-jvm:4.4.3")
-	implementation("io.kotest:kotest-extensions-spring:4.4.3")
-	testImplementation("io.mockk:mockk:1.12.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/spi/QueryMissionPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/spi/QueryMissionPort.kt
@@ -2,11 +2,10 @@ package com.stack.knowledge.domain.mission.application.spi
 
 import com.stack.knowledge.domain.mission.domain.Mission
 import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
-import com.stack.knowledge.domain.user.domain.User
-import java.util.UUID
+import java.util.*
 
 interface QueryMissionPort {
     fun queryMissionById(missionId: UUID): Mission?
-    fun queryAllMissionByUser(user: User): List<Mission>
+    fun queryAllMissionByUserId(userId: UUID): List<Mission>
     fun queryAllMissionByMissionStatus(missionStatus: MissionStatus): List<Mission>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/MissionPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/MissionPersistenceAdapter.kt
@@ -5,7 +5,6 @@ import com.stack.knowledge.domain.mission.domain.Mission
 import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
 import com.stack.knowledge.domain.mission.persistence.mapper.MissionMapper
 import com.stack.knowledge.domain.mission.persistence.repository.MissionJpaRepository
-import com.stack.knowledge.domain.user.domain.User
 import com.stack.knowledge.domain.user.persistence.mapper.UserMapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -24,8 +23,8 @@ class MissionPersistenceAdapter(
     override fun queryMissionById(missionId: UUID): Mission? =
         missionMapper.toDomain(missionJpaRepository.findByIdOrNull(missionId))
 
-    override fun queryAllMissionByUser(user: User): List<Mission> =
-        missionJpaRepository.findAllByUser(userMapper.toEntity(user)).map { missionMapper.toDomain(it)!! }
+    override fun queryAllMissionByUserId(userId: UUID): List<Mission> =
+        missionJpaRepository.findAllByUserId(userId).map { missionMapper.toDomain(it)!! }
 
     override fun queryAllMissionByMissionStatus(missionStatus: MissionStatus): List<Mission> =
         missionJpaRepository.findByMissionStatus(missionStatus).map { missionMapper.toDomain(it)!! }

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/repository/MissionJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/repository/MissionJpaRepository.kt
@@ -2,11 +2,10 @@ package com.stack.knowledge.domain.mission.persistence.repository
 
 import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
 import com.stack.knowledge.domain.mission.persistence.entity.MissionJpaEntity
-import com.stack.knowledge.domain.user.persistence.entity.UserJpaEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
+import java.util.*
 
 interface MissionJpaRepository : CrudRepository<MissionJpaEntity, UUID> {
-    fun findAllByUser(userJpaEntity: UserJpaEntity): List<MissionJpaEntity>
+    fun findAllByUserId(userId: UUID): List<MissionJpaEntity>
     fun findByMissionStatus(missionStatus: MissionStatus): List<MissionJpaEntity>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/solve/application/spi/QuerySolvePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/solve/application/spi/QuerySolvePort.kt
@@ -8,6 +8,5 @@ import java.util.UUID
 interface QuerySolvePort {
     fun queryAllSolveBySolveStatusAndMission(solveStatus: SolveStatus, mission: Mission): List<Solve>
     fun querySolveById(solveId: UUID): Solve?
-    fun queryAllSolveByMission(mission: Mission): List<Solve>
     fun queryAllSolveByStudentId(studentId: UUID): List<Solve>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/SolvePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/SolvePersistenceAdapter.kt
@@ -26,9 +26,6 @@ class SolvePersistenceAdapter(
     override fun querySolveById(solveId: UUID): Solve? =
         solveMapper.toDomain(solveJpaRepository.findByIdOrNull(solveId))
 
-    override fun queryAllSolveByMission(mission: Mission): List<Solve> =
-        solveJpaRepository.findAllByMission(missionMapper.toEntity(mission)).map { solveMapper.toDomain(it)!! }
-
     override fun queryAllSolveByStudentId(studentId: UUID): List<Solve> =
         solveJpaRepository.findAllByStudentId(studentId).map { solveMapper.toDomain(it)!! }
 

--- a/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/repository/SolveJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/repository/SolveJpaRepository.kt
@@ -7,7 +7,6 @@ import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
 interface SolveJpaRepository : CrudRepository<SolveJpaEntity, UUID> {
-    fun findAllByMission(missionJpaEntity: MissionJpaEntity): List<SolveJpaEntity>
     fun findAllBySolveStatusAndMission(solveStatus: SolveStatus, missionJpaEntity: MissionJpaEntity): List<SolveJpaEntity>
     fun findAllByStudentId(studentId: UUID): List<SolveJpaEntity>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageUseCase.kt
@@ -40,7 +40,7 @@ class QueryScoringPageUseCase(
                     title = mission.title,
                     point = point.missionPoint,
                     user = UserResponse(
-                        id = mission.id,
+                        id = user.id,
                         email = user.email,
                         name = user.name,
                         profileImage = user.profileImage

--- a/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/QueryScoringPageUseCase.kt
@@ -1,16 +1,18 @@
 package com.stack.knowledge.domain.user.application.usecase
 
-import com.stack.knowledge.domain.solve.application.spi.QuerySolvePort
-import com.stack.knowledge.domain.user.presentation.data.response.AllScoringResponse
 import com.stack.knowledge.common.annotation.usecase.ReadOnlyUseCase
 import com.stack.knowledge.common.spi.SecurityPort
 import com.stack.knowledge.domain.mission.application.spi.QueryMissionPort
 import com.stack.knowledge.domain.mission.exception.MissionNotFoundException
-import com.stack.knowledge.domain.solve.domain.constant.SolveStatus
 import com.stack.knowledge.domain.point.application.spi.QueryPointPort
 import com.stack.knowledge.domain.point.exception.PointNotFoundException
+import com.stack.knowledge.domain.solve.application.spi.QuerySolvePort
+import com.stack.knowledge.domain.solve.domain.constant.SolveStatus
+import com.stack.knowledge.domain.student.application.spi.QueryStudentPort
+import com.stack.knowledge.domain.student.exception.StudentNotFoundException
 import com.stack.knowledge.domain.user.application.spi.QueryUserPort
 import com.stack.knowledge.domain.user.exception.UserNotFoundException
+import com.stack.knowledge.domain.user.presentation.data.response.AllScoringResponse
 import com.stack.knowledge.domain.user.presentation.data.response.UserResponse
 
 @ReadOnlyUseCase
@@ -19,17 +21,18 @@ class QueryScoringPageUseCase(
     private val queryUserPort: QueryUserPort,
     private val queryPointPort: QueryPointPort,
     private val queryMissionPort: QueryMissionPort,
-    private val securityPort: SecurityPort
+    private val securityPort: SecurityPort,
+    private val queryStudentPort: QueryStudentPort
 ) {
     fun execute(): List<AllScoringResponse> {
-        val user = securityPort.queryCurrentUserId().let {
-            queryUserPort.queryUserById(it) ?: throw UserNotFoundException()
-        }
+        val userId = securityPort.queryCurrentUserId()
 
-        return queryMissionPort.queryAllMissionByUser(user).flatMap {
+        return queryMissionPort.queryAllMissionByUserId(userId).flatMap {
             querySolvePort.queryAllSolveBySolveStatusAndMission(SolveStatus.SCORING, it).map { solve ->
                 val point = queryPointPort.queryPointBySolve(solve) ?: throw PointNotFoundException()
                 val mission = queryMissionPort.queryMissionById(solve.mission) ?: throw MissionNotFoundException()
+                val student = queryStudentPort.queryStudentById(solve.student) ?: throw StudentNotFoundException()
+                val user = queryUserPort.queryUserById(student.user) ?: throw UserNotFoundException()
 
                 AllScoringResponse(
                     solveId = solve.id,
@@ -37,7 +40,7 @@ class QueryScoringPageUseCase(
                     title = mission.title,
                     point = point.missionPoint,
                     user = UserResponse(
-                        id = user.id,
+                        id = mission.id,
                         email = user.email,
                         name = user.name,
                         profileImage = user.profileImage

--- a/src/main/kotlin/com/stack/knowledge/domain/user/persistence/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/persistence/repository/UserJpaRepository.kt
@@ -1,10 +1,10 @@
 package com.stack.knowledge.domain.user.persistence.repository
 
 import com.stack.knowledge.domain.user.persistence.entity.UserJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
+import org.springframework.data.repository.CrudRepository
+import java.util.*
 
-interface UserJpaRepository : JpaRepository<UserJpaEntity, UUID> {
+interface UserJpaRepository : CrudRepository<UserJpaEntity, UUID> {
     fun findByEmail(email: String): UserJpaEntity?
     fun existsByEmail(email: String): Boolean
 }


### PR DESCRIPTION
## 💡 개요
채점할 문제 전체 조회 API 수정
## 📃 작업내용
사용하지 않는 jpa method를 삭제 해주었습니다.
JpaRepository를 사용하지 않고 CrudRepository만을 이용해 구현할 수 있어 변경해 주었습니다.
채점 페이지에서 문제를 만든 선생님의 정보를 반환하는 것이 아닌 문제를 푼 학생의 정보를 반환하도록 변경해 주었습니다.