### PR TITLE
# 120 Time limit 관련 hotfix

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/common/service/SecurityService.kt
+++ b/src/main/kotlin/com/stack/knowledge/common/service/SecurityService.kt
@@ -1,8 +1,10 @@
 package com.stack.knowledge.common.service
 
 import com.stack.knowledge.domain.user.domain.User
+import java.util.UUID
 
 interface SecurityService {
     fun queryCurrentUser(): User
     fun queryCurrentUserAuthority(): String
+    fun queryCurrentUserId(): UUID
 }

--- a/src/main/kotlin/com/stack/knowledge/common/service/impl/SecurityServiceImpl.kt
+++ b/src/main/kotlin/com/stack/knowledge/common/service/impl/SecurityServiceImpl.kt
@@ -10,6 +10,7 @@ import com.stack.knowledge.domain.user.domain.constant.Authority
 import com.stack.knowledge.domain.user.exception.UserNotFoundException
 import com.stack.knowledge.global.security.exception.InvalidRoleException
 import org.springframework.stereotype.Service
+import java.util.*
 
 
 @Service
@@ -32,4 +33,7 @@ class SecurityServiceImpl(
 
     override fun queryCurrentUserAuthority(): String =
         securityPort.queryCurrentUserAuthority()
+
+    override fun queryCurrentUserId(): UUID =
+        securityPort.queryCurrentUserId()
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/usecase/QueryMissionDetailsUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/usecase/QueryMissionDetailsUseCase.kt
@@ -4,19 +4,34 @@ import com.stack.knowledge.domain.mission.application.spi.MissionPort
 import com.stack.knowledge.domain.mission.exception.MissionNotFoundException
 import com.stack.knowledge.domain.mission.presentation.data.response.MissionDetailsResponse
 import com.stack.knowledge.common.annotation.usecase.ReadOnlyUseCase
+import com.stack.knowledge.common.annotation.usecase.UseCase
+import com.stack.knowledge.domain.mission.application.spi.CommandMissionPort
+import com.stack.knowledge.domain.mission.application.spi.QueryMissionPort
 import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
 import com.stack.knowledge.domain.mission.exception.MissionNotOpenedException
+import com.stack.knowledge.domain.time.application.spi.CommandTimePort
+import com.stack.knowledge.domain.time.domain.Time
+import java.time.LocalDateTime
 import java.util.UUID
 
-@ReadOnlyUseCase
+@UseCase
 class QueryMissionDetailsUseCase(
-    private val missionPort: MissionPort
+    private val queryMissionPort: QueryMissionPort,
+    private val commandTimePort: CommandTimePort
 ) {
     fun execute(id: UUID): MissionDetailsResponse {
-        val mission = missionPort.queryMissionById(id) ?: throw MissionNotFoundException()
+        val mission = queryMissionPort.queryMissionById(id) ?: throw MissionNotFoundException()
 
         if (mission.missionStatus != MissionStatus.OPENED)
             throw MissionNotOpenedException()
+
+        val time = Time(
+            id = UUID.randomUUID(),
+            mission = mission.id,
+            createdAt = LocalDateTime.now()
+        )
+
+        commandTimePort.save(time)
 
         return MissionDetailsResponse(
             title = mission.title,

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/CommandTimePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/CommandTimePort.kt
@@ -1,0 +1,7 @@
+package com.stack.knowledge.domain.time.application.spi
+
+import com.stack.knowledge.domain.time.domain.Time
+
+interface CommandTimePort {
+    fun save(time: Time)
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/QueryTimePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/QueryTimePort.kt
@@ -1,0 +1,4 @@
+package com.stack.knowledge.domain.time.application.spi
+
+interface QueryTimePort {
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/QueryTimePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/QueryTimePort.kt
@@ -1,4 +1,8 @@
 package com.stack.knowledge.domain.time.application.spi
 
+import com.stack.knowledge.domain.mission.domain.Mission
+import com.stack.knowledge.domain.time.domain.Time
+
 interface QueryTimePort {
+    fun queryTimeByMission(mission: Mission): Time?
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/StudentPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/StudentPort.kt
@@ -1,0 +1,4 @@
+package com.stack.knowledge.domain.time.application.spi
+
+interface StudentPort : CommandTimePort, QueryTimePort {
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/StudentPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/StudentPort.kt
@@ -1,4 +1,0 @@
-package com.stack.knowledge.domain.time.application.spi
-
-interface StudentPort : CommandTimePort, QueryTimePort {
-}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/TimePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/TimePort.kt
@@ -1,0 +1,3 @@
+package com.stack.knowledge.domain.time.application.spi
+
+interface TimePort : CommandTimePort, QueryTimePort

--- a/src/main/kotlin/com/stack/knowledge/domain/time/domain/Time.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/domain/Time.kt
@@ -1,0 +1,11 @@
+package com.stack.knowledge.domain.time.domain
+
+import com.stack.knowledge.domain.mission.domain.Mission
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class Time(
+    val id: UUID,
+    val mission: Mission,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/stack/knowledge/domain/time/domain/Time.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/domain/Time.kt
@@ -1,11 +1,10 @@
 package com.stack.knowledge.domain.time.domain
 
-import com.stack.knowledge.domain.mission.domain.Mission
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 data class Time(
     val id: UUID,
-    val mission: Mission,
+    val mission: UUID,
     val createdAt: LocalDateTime
 )

--- a/src/main/kotlin/com/stack/knowledge/domain/time/exception/TimeLimitExceededException.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/exception/TimeLimitExceededException.kt
@@ -1,0 +1,6 @@
+package com.stack.knowledge.domain.time.exception
+
+import com.stack.knowledge.global.error.ErrorCode
+import com.stack.knowledge.global.error.exception.StackKnowledgeException
+
+class TimeLimitExceededException : StackKnowledgeException(ErrorCode.TIME_LIMIT_EXCEEDED)

--- a/src/main/kotlin/com/stack/knowledge/domain/time/exception/TimeNotFoundException.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/exception/TimeNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.stack.knowledge.domain.time.exception
+
+import com.stack.knowledge.global.error.ErrorCode
+import com.stack.knowledge.global.error.exception.StackKnowledgeException
+
+class TimeNotFoundException : StackKnowledgeException(ErrorCode.TIME_NOT_FOUND)

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
@@ -1,5 +1,7 @@
 package com.stack.knowledge.domain.time.persistence
 
+import com.stack.knowledge.domain.mission.domain.Mission
+import com.stack.knowledge.domain.mission.persistence.mapper.MissionMapper
 import com.stack.knowledge.domain.time.application.spi.StudentPort
 import com.stack.knowledge.domain.time.domain.Time
 import com.stack.knowledge.domain.time.persistence.mapper.TimeMapper
@@ -9,9 +11,13 @@ import org.springframework.stereotype.Component
 @Component
 class TimePersistenceAdapter(
     private val timeJpaRepository: TimeJpaRepository,
-    private val timeMapper: TimeMapper
+    private val timeMapper: TimeMapper,
+    private val missionMapper: MissionMapper
 ) : StudentPort {
     override fun save(time: Time) {
         timeJpaRepository.save(timeMapper.toEntity(time))
     }
+
+    override fun queryTimeByMission(mission: Mission): Time? =
+        timeMapper.toDomain(timeJpaRepository.findByMissionJpaEntity(missionMapper.toEntity(mission)))
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
@@ -1,0 +1,17 @@
+package com.stack.knowledge.domain.time.persistence
+
+import com.stack.knowledge.domain.time.application.spi.StudentPort
+import com.stack.knowledge.domain.time.domain.Time
+import com.stack.knowledge.domain.time.persistence.mapper.TimeMapper
+import com.stack.knowledge.domain.time.persistence.repository.TimeJpaRepository
+import org.springframework.stereotype.Component
+
+@Component
+class TimePersistenceAdapter(
+    private val timeJpaRepository: TimeJpaRepository,
+    private val timeMapper: TimeMapper
+) : StudentPort {
+    override fun save(time: Time) {
+        timeJpaRepository.save(timeMapper.toEntity(time))
+    }
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.stack.knowledge.domain.time.persistence
 
 import com.stack.knowledge.domain.mission.domain.Mission
 import com.stack.knowledge.domain.mission.persistence.mapper.MissionMapper
-import com.stack.knowledge.domain.time.application.spi.StudentPort
+import com.stack.knowledge.domain.time.application.spi.TimePort
 import com.stack.knowledge.domain.time.domain.Time
 import com.stack.knowledge.domain.time.persistence.mapper.TimeMapper
 import com.stack.knowledge.domain.time.persistence.repository.TimeJpaRepository
@@ -13,7 +13,7 @@ class TimePersistenceAdapter(
     private val timeJpaRepository: TimeJpaRepository,
     private val timeMapper: TimeMapper,
     private val missionMapper: MissionMapper
-) : StudentPort {
+) : TimePort {
     override fun save(time: Time) {
         timeJpaRepository.save(timeMapper.toEntity(time))
     }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/entity/TimeJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/entity/TimeJpaEntity.kt
@@ -1,0 +1,18 @@
+package com.stack.knowledge.domain.time.persistence.entity
+
+import com.stack.knowledge.common.entity.BaseIdEntity
+import com.stack.knowledge.domain.mission.persistence.entity.MissionJpaEntity
+import java.util.*
+import javax.persistence.*
+
+@Entity
+@Table(name = "time")
+class TimeJpaEntity(
+
+    override val id: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    val missionJpaEntity: MissionJpaEntity
+
+) : BaseIdEntity(id)

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/mapper/TimeMapper.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/mapper/TimeMapper.kt
@@ -1,0 +1,32 @@
+package com.stack.knowledge.domain.time.persistence.mapper
+
+import com.stack.knowledge.domain.mission.exception.MissionNotFoundException
+import com.stack.knowledge.domain.mission.persistence.repository.MissionJpaRepository
+import com.stack.knowledge.domain.time.domain.Time
+import com.stack.knowledge.domain.time.persistence.entity.TimeJpaEntity
+import com.stack.knowledge.global.mapper.GenericMapper
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class TimeMapper(
+    private val missionJpaRepository: MissionJpaRepository
+) : GenericMapper<Time, TimeJpaEntity> {
+    override fun toDomain(entity: TimeJpaEntity?): Time? =
+        entity?.let {
+            Time(
+                id = it.id,
+                mission = it.missionJpaEntity.id,
+                createdAt = entity.createdAt
+            )
+        }
+
+    override fun toEntity(domain: Time): TimeJpaEntity {
+        val mission = missionJpaRepository.findByIdOrNull(domain.mission) ?: throw MissionNotFoundException()
+
+        return TimeJpaEntity(
+            id = domain.id,
+            missionJpaEntity = mission,
+        )
+    }
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
@@ -1,7 +1,10 @@
 package com.stack.knowledge.domain.time.persistence.repository
 
+import com.stack.knowledge.domain.mission.persistence.entity.MissionJpaEntity
 import com.stack.knowledge.domain.time.persistence.entity.TimeJpaEntity
 import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
-interface TimeJpaRepository : CrudRepository<TimeJpaEntity, UUID>
+interface TimeJpaRepository : CrudRepository<TimeJpaEntity, UUID> {
+    fun findByMissionJpaEntity(missionJpaEntity: MissionJpaEntity): TimeJpaEntity
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.stack.knowledge.domain.time.persistence.repository
+
+import com.stack.knowledge.domain.time.persistence.entity.TimeJpaEntity
+import org.springframework.data.repository.CrudRepository
+import java.util.UUID
+
+interface TimeJpaRepository : CrudRepository<TimeJpaEntity, UUID>

--- a/src/main/kotlin/com/stack/knowledge/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/error/ErrorCode.kt
@@ -34,6 +34,10 @@ enum class ErrorCode(
     ALREADY_SOLVED("이미 푼 문제입니다.", 409),
     UNSUPPORTED_SOLVE_STATUS("지원하지 않는 문제 채점 방식입니다.", 400),
 
+    // time
+    TIME_NOT_FOUND("존재하지 않는 문제입니다.", 404),
+    TIME_LIMIT_EXCEEDED("시간 제한을 초과하였습니다.", 400),
+
     // user
     USER_NOT_FOUND("존재하지 않는 유저입니다.", 404),
 


### PR DESCRIPTION
## 💡 개요
Time limit 관련 hotfix
## 📃 작업내용
유저가 개발자 도구를 이용하여 시간을 멈추는 등의 행동을 했을 때 클라이언트 측에서 막을 수 없다는 이슈가 생겼습니다.
그래서 서버에서 예외처리를 해주기로 결정하여 미션 상세 조회와 미션 제출할 때 time 도메인에 시간을 저장하여 비교하는 식의 작업을 추가해주었습니다.
time entity를 mission entity와 연관관계를 지어주었습니다.