### PR TITLE
# 133 굳이 필요없는 타입 선언 제거

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/common/service/impl/SecurityServiceImpl.kt
+++ b/src/main/kotlin/com/stack/knowledge/common/service/impl/SecurityServiceImpl.kt
@@ -12,7 +12,6 @@ import com.stack.knowledge.global.security.exception.InvalidRoleException
 import org.springframework.stereotype.Service
 import java.util.*
 
-
 @Service
 class SecurityServiceImpl(
     private val securityPort: SecurityPort,

--- a/src/main/kotlin/com/stack/knowledge/domain/item/persistence/entity/ItemJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/item/persistence/entity/ItemJpaEntity.kt
@@ -12,7 +12,7 @@ class ItemJpaEntity(
 
     override val id: UUID,
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     val name: String,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/ScoreSolveUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/user/application/usecase/ScoreSolveUseCase.kt
@@ -47,7 +47,6 @@ class ScoreSolveUseCase(
             SolveStatus.CORRECT_ANSWER -> {
                 val lowPoint = queryPointPort.queryTopByMissionIdOrderByMissionPointAsc(mission.id) ?: throw PointNotFoundException()
                 missionPort.save(mission.copy(point = lowPoint.missionPoint))
-
                 Pair(student.currentPoint + point.missionPoint, student.cumulatePoint + point.missionPoint)
             }
             SolveStatus.WRONG_ANSWER -> Pair(student.currentPoint, student.cumulatePoint)

--- a/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
@@ -86,7 +86,4 @@ class SecurityConfig(
             .apply(FilterConfig(jwtParserPort))
             .and()
             .build()
-
-    @Bean
-    fun passwordEncoder() = BCryptPasswordEncoder()
 }

--- a/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
@@ -10,7 +10,6 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.util.matcher.RequestMatcher
 import org.springframework.web.cors.CorsUtils

--- a/src/main/kotlin/com/stack/knowledge/thirdparty/aws/s3/AwsS3Adapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/thirdparty/aws/s3/AwsS3Adapter.kt
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.server.ResponseStatusException
-import java.io.IOException
 
 @Component
 class AwsS3Adapter(
@@ -29,16 +28,18 @@ class AwsS3Adapter(
 
     private fun inputS3(multipartFile: MultipartFile, fileName: String) {
         val objectMetadata = ObjectMetadata()
+
         objectMetadata.contentLength = multipartFile.size
         objectMetadata.contentType = multipartFile.contentType
-        try {
+
+        runCatching {
             amazonS3.putObject(
                 PutObjectRequest(awsS3Properties.bucket, fileName, multipartFile.inputStream, objectMetadata)
                     .withCannedAcl(
                         CannedAccessControlList.PublicRead
                     )
             )
-        } catch (e: IOException) {
+        }.onFailure {
             throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.")
         }
     }

--- a/src/main/kotlin/com/stack/knowledge/thirdparty/aws/s3/config/AwsS3Config.kt
+++ b/src/main/kotlin/com/stack/knowledge/thirdparty/aws/s3/config/AwsS3Config.kt
@@ -1,6 +1,5 @@
 package com.stack.knowledge.thirdparty.aws.s3.config
 
-import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.AmazonS3
@@ -19,7 +18,7 @@ class AwsS3Config(
 
     @Bean
     fun amazonS3(): AmazonS3 {
-        val awsCredentials: AWSCredentials = BasicAWSCredentials(awsProperties.accessKey, awsProperties.secretKey)
+        val awsCredentials = BasicAWSCredentials(awsProperties.accessKey, awsProperties.secretKey)
         return AmazonS3ClientBuilder.standard()
             .withRegion(region)
             .withCredentials(AWSStaticCredentialsProvider(awsCredentials))

--- a/src/main/kotlin/com/stack/knowledge/thirdparty/gauth/config/GAuthConfig.kt
+++ b/src/main/kotlin/com/stack/knowledge/thirdparty/gauth/config/GAuthConfig.kt
@@ -1,6 +1,5 @@
 package com.stack.knowledge.thirdparty.gauth.config
 
-import gauth.GAuth
 import gauth.impl.GAuthImpl
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -8,5 +7,5 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class GAuthConfig {
     @Bean
-    fun gAuth(): GAuth = GAuthImpl()
+    fun gAuth() = GAuthImpl()
 }


### PR DESCRIPTION
## 💡 개요
굳이 필요없는 타입 선언 제거
## 📃 작업내용
굳이 명시해줄 필요 없는 타입 선언을 제거했습니다.
item 의 name 필드를 unique 하게 설정했습니다.
aws s3 adapter 의 try - catch 문을 runCatching 으로 변경해주었습니다.
사용하지 않는 password encoder 를 삭제해주었습니다.