### PR TITLE
# 138 스케줄러 Point, Time 삭제 로직 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,19 +9,6 @@ plugins {
 	kotlin("kapt") version "1.6.21"
 }
 
-allOpen {
-	annotation("javax.persistence.Entity")
-	annotation("javax.persistence.MappedSuperclass")
-	annotation("javax.persistence.Embeddable")
-}
-
-noArg {
-	annotation("javax.persistence.Entity")
-	annotation("javax.persistence.MappedSuperclass")
-	annotation("javax.persistence.Embeddable")
-}
-
-
 group = "com.stack"
 version = "0.0.1-SNAPSHOT"
 

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
@@ -1,41 +1,41 @@
 package com.stack.knowledge.domain.mission.application.scheduler
 
-import com.stack.knowledge.domain.mission.application.spi.MissionPort
-import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
-import com.stack.knowledge.domain.point.application.spi.CommandPointPort
-import com.stack.knowledge.domain.time.application.spi.CommandTimePort
-import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
-
-@Component
-class MissionScheduler(
-    private val missionPort: MissionPort,
-    private val commandTimePort: CommandTimePort,
-    private val commandPointPort: CommandPointPort
-) {
-    @Scheduled(cron = "0 30 12 ? * 1-5")
-    fun openAllMission() = checkAndChangeMissionStatusOpened()
-
-    @Scheduled(cron = "0 30 19 ? * 1-5")
-    fun closeAllMission() = checkAndChangeMissionStatusClosed()
-
-    private fun checkAndChangeMissionStatusOpened() {
-        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.AVAILABLE_OPEN)
-
-        missions.map {
-            missionPort.save(it.copy(missionStatus = MissionStatus.OPENED))
-        }
-    }
-
-    private fun checkAndChangeMissionStatusClosed() {
-        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
-        val missionIds = missions.map { it.id }
-
-        commandTimePort.deleteAllByMissionIds(missionIds)
-        commandPointPort.deleteAllByMissionIds(missionIds)
-
-        missions.map {
-            missionPort.save(it.copy(missionStatus = MissionStatus.CLOSED))
-        }
-    }
-}
+//import com.stack.knowledge.domain.mission.application.spi.MissionPort
+//import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
+//import com.stack.knowledge.domain.point.application.spi.CommandPointPort
+//import com.stack.knowledge.domain.time.application.spi.CommandTimePort
+//import org.springframework.scheduling.annotation.Scheduled
+//import org.springframework.stereotype.Component
+//
+//@Component
+//class MissionScheduler(
+//    private val missionPort: MissionPort,
+//    private val commandTimePort: CommandTimePort,
+//    private val commandPointPort: CommandPointPort
+//) {
+//    @Scheduled(cron = "0 30 12 ? * 1-5")
+//    fun openAllMission() = checkAndChangeMissionStatusOpened()
+//
+//    @Scheduled(cron = "0 30 19 ? * 1-5")
+//    fun closeAllMission() = checkAndChangeMissionStatusClosed()
+//
+//    private fun checkAndChangeMissionStatusOpened() {
+//        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.AVAILABLE_OPEN)
+//
+//        missions.map {
+//            missionPort.save(it.copy(missionStatus = MissionStatus.OPENED))
+//        }
+//    }
+//
+//    private fun checkAndChangeMissionStatusClosed() {
+//        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
+//        val missionIds = missions.map { it.id }
+//
+//        commandTimePort.deleteAllByMissionIds(missionIds)
+//        commandPointPort.deleteAllByMissionIds(missionIds)
+//
+//        missions.map {
+//            missionPort.save(it.copy(missionStatus = MissionStatus.CLOSED))
+//        }
+//    }
+//}

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
@@ -29,7 +29,6 @@ class MissionScheduler(
 
     private fun checkAndChangeMissionStatusClosed() {
         val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
-
         val missionIds = missions.map { it.id }
 
         commandTimePort.deleteAllByMissionIds(missionIds)

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
@@ -5,29 +5,29 @@ import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
-//@Component
-//class MissionScheduler(
-//    private val missionPort: MissionPort
-//) {
-//    @Scheduled(cron = "0 30 12 ? * 1-5")
-//    fun openAllMission() = checkAndChangeMissionStatusOpened()
-//
-//    @Scheduled(cron = "0 30 19 ? * 1-5")
-//    fun closeAllMission() = checkAndChangeMissionStatusClosed()
-//
-//    private fun checkAndChangeMissionStatusOpened() {
-//        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.AVAILABLE_OPEN)
-//
-//        missions.map {
-//            missionPort.save(it.copy(missionStatus = MissionStatus.OPENED))
-//        }
-//    }
-//
-//    private fun checkAndChangeMissionStatusClosed() {
-//        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
-//
-//        missions.map {
-//            missionPort.save(it.copy(missionStatus = MissionStatus.CLOSED))
-//        }
-//    }
-//}
+@Component
+class MissionScheduler(
+    private val missionPort: MissionPort
+) {
+    @Scheduled(cron = "0 30 12 ? * 1-5")
+    fun openAllMission() = checkAndChangeMissionStatusOpened()
+
+    @Scheduled(cron = "0 30 19 ? * 1-5")
+    fun closeAllMission() = checkAndChangeMissionStatusClosed()
+
+    private fun checkAndChangeMissionStatusOpened() {
+        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.AVAILABLE_OPEN)
+
+        missions.map {
+            missionPort.save(it.copy(missionStatus = MissionStatus.OPENED))
+        }
+    }
+
+    private fun checkAndChangeMissionStatusClosed() {
+        val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
+
+        missions.map {
+            missionPort.save(it.copy(missionStatus = MissionStatus.CLOSED))
+        }
+    }
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/scheduler/MissionScheduler.kt
@@ -2,12 +2,16 @@ package com.stack.knowledge.domain.mission.application.scheduler
 
 import com.stack.knowledge.domain.mission.application.spi.MissionPort
 import com.stack.knowledge.domain.mission.domain.constant.MissionStatus
+import com.stack.knowledge.domain.point.application.spi.CommandPointPort
+import com.stack.knowledge.domain.time.application.spi.CommandTimePort
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
 class MissionScheduler(
-    private val missionPort: MissionPort
+    private val missionPort: MissionPort,
+    private val commandTimePort: CommandTimePort,
+    private val commandPointPort: CommandPointPort
 ) {
     @Scheduled(cron = "0 30 12 ? * 1-5")
     fun openAllMission() = checkAndChangeMissionStatusOpened()
@@ -25,6 +29,11 @@ class MissionScheduler(
 
     private fun checkAndChangeMissionStatusClosed() {
         val missions = missionPort.queryAllMissionByMissionStatus(MissionStatus.OPENED)
+
+        val missionIds = missions.map { it.id }
+
+        commandTimePort.deleteAllByMissionIds(missionIds)
+        commandPointPort.deleteAllByMissionIds(missionIds)
 
         missions.map {
             missionPort.save(it.copy(missionStatus = MissionStatus.CLOSED))

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/application/spi/QueryMissionPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/application/spi/QueryMissionPort.kt
@@ -6,6 +6,7 @@ import java.util.*
 
 interface QueryMissionPort {
     fun queryMissionById(missionId: UUID): Mission?
+    fun queryAllMissionByMissionStatus(missionStatus: MissionStatus): List<Mission>
     fun queryAllMissionsByUserIdOrderByCreatedAtDesc(userId: UUID): List<Mission>
     fun queryAllMissionByMissionStatusOrderByCreatedAtDesc(missionStatus: MissionStatus): List<Mission>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/MissionPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/MissionPersistenceAdapter.kt
@@ -21,6 +21,9 @@ class MissionPersistenceAdapter(
     override fun queryMissionById(missionId: UUID): Mission? =
         missionMapper.toDomain(missionJpaRepository.findByIdOrNull(missionId))
 
+    override fun queryAllMissionByMissionStatus(missionStatus: MissionStatus): List<Mission> =
+        missionJpaRepository.findAllByMissionStatus(missionStatus).map { missionMapper.toDomain(it)!! }
+
     override fun queryAllMissionsByUserIdOrderByCreatedAtDesc(userId: UUID): List<Mission> =
         missionJpaRepository.findAllByUserIdOrderByCreatedAtDesc(userId).map { missionMapper.toDomain(it)!! }
 

--- a/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/repository/MissionJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/mission/persistence/repository/MissionJpaRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface MissionJpaRepository : CrudRepository<MissionJpaEntity, UUID> {
+    fun findAllByMissionStatus(missionStatus: MissionStatus): List<MissionJpaEntity>
     fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<MissionJpaEntity>
     @EntityGraph(attributePaths = ["user"])
     fun findAllByMissionStatusOrderByCreatedAtDesc(missionStatus: MissionStatus): List<MissionJpaEntity>

--- a/src/main/kotlin/com/stack/knowledge/domain/order/persistence/repository/OrderJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/order/persistence/repository/OrderJpaRepository.kt
@@ -3,9 +3,9 @@ package com.stack.knowledge.domain.order.persistence.repository
 import com.stack.knowledge.domain.order.persistence.entity.OrderJpaEntity
 import com.stack.knowledge.domain.student.persistence.entity.StudentJpaEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
+import java.util.*
 
 interface OrderJpaRepository : CrudRepository<OrderJpaEntity, UUID> {
-    fun findAllByStudent(studentJpaEntity: StudentJpaEntity): List<OrderJpaEntity>
+    fun findAllByStudent(student: StudentJpaEntity): List<OrderJpaEntity>
     fun findAllByOrderByCreatedAtDesc(): List<OrderJpaEntity>
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/point/application/spi/CommandPointPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/application/spi/CommandPointPort.kt
@@ -1,7 +1,9 @@
 package com.stack.knowledge.domain.point.application.spi
 
 import com.stack.knowledge.domain.point.domain.Point
+import java.util.*
 
 interface CommandPointPort {
     fun save(point: Point)
+    fun deleteAllByMissionIds(missionIds: List<UUID>)
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
@@ -20,7 +20,7 @@ class PointPersistenceAdapter(
     }
 
     override fun deleteAllByMissionIds(missionIds: List<UUID>) {
-        pointJpaRepository.deleteAllByMissionJpaEntityIds(missionIds)
+        pointJpaRepository.deleteAllByMissionIds(missionIds)
     }
 
     override fun queryPointBySolve(solve: Solve): Point? =

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/PointPersistenceAdapter.kt
@@ -19,6 +19,10 @@ class PointPersistenceAdapter(
         pointJpaRepository.save(pointMapper.toEntity(point))
     }
 
+    override fun deleteAllByMissionIds(missionIds: List<UUID>) {
+        pointJpaRepository.deleteAllByMissionJpaEntityIds(missionIds)
+    }
+
     override fun queryPointBySolve(solve: Solve): Point? =
         pointMapper.toDomain(pointJpaRepository.findBySolve(solveMapper.toEntity(solve)))
 

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
@@ -2,10 +2,15 @@ package com.stack.knowledge.domain.point.persistence.repository
 
 import com.stack.knowledge.domain.point.persistence.entity.PointJpaEntity
 import com.stack.knowledge.domain.solve.persistence.entity.SolveJpaEntity
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface PointJpaRepository : CrudRepository<PointJpaEntity, Long> {
     fun findBySolve(solveJpaEntity: SolveJpaEntity): PointJpaEntity?
     fun findTopByMissionIdOrderByMissionPointAsc(missionId: UUID): PointJpaEntity?
+    @Modifying
+    @Query("delete from PointJpaEntity p where p.mission in :missionIds")
+    fun deleteAllByMissionJpaEntityIds(missionIds: List<UUID>)
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/point/persistence/repository/PointJpaRepository.kt
@@ -8,9 +8,9 @@ import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface PointJpaRepository : CrudRepository<PointJpaEntity, Long> {
-    fun findBySolve(solveJpaEntity: SolveJpaEntity): PointJpaEntity?
+    fun findBySolve(solve: SolveJpaEntity): PointJpaEntity?
     fun findTopByMissionIdOrderByMissionPointAsc(missionId: UUID): PointJpaEntity?
     @Modifying
     @Query("delete from PointJpaEntity p where p.mission in :missionIds")
-    fun deleteAllByMissionJpaEntityIds(missionIds: List<UUID>)
+    fun deleteAllByMissionIds(missionIds: List<UUID>)
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/repository/SolveJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/solve/persistence/repository/SolveJpaRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface SolveJpaRepository : CrudRepository<SolveJpaEntity, UUID> {
-    fun findAllBySolveStatusAndMissionOrderByCreatedAtDesc(solveStatus: SolveStatus, missionJpaEntity: MissionJpaEntity): List<SolveJpaEntity>
+    fun findAllBySolveStatusAndMissionOrderByCreatedAtDesc(solveStatus: SolveStatus, mission: MissionJpaEntity): List<SolveJpaEntity>
     fun findAllByStudentId(studentId: UUID): List<SolveJpaEntity>
     fun existsByStudentIdAndMissionId(studentId: UUID, missionId: UUID): Boolean
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/student/persistence/repository/StudentJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/student/persistence/repository/StudentJpaRepository.kt
@@ -10,5 +10,5 @@ interface StudentJpaRepository : CrudRepository<StudentJpaEntity, UUID> {
     @Query("SELECT s FROM StudentJpaEntity s JOIN FETCH s.user order by s.cumulatePoint DESC")
     fun findAllByOrderByCumulatePointDesc(): List<StudentJpaEntity>
     fun findByUserId(userId: UUID): StudentJpaEntity
-    fun existsByUser(userJpaEntity: UserJpaEntity): Boolean
+    fun existsByUser(user: UserJpaEntity): Boolean
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/CommandTimePort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/application/spi/CommandTimePort.kt
@@ -1,7 +1,9 @@
 package com.stack.knowledge.domain.time.application.spi
 
 import com.stack.knowledge.domain.time.domain.Time
+import java.util.*
 
 interface CommandTimePort {
     fun save(time: Time)
+    fun deleteAllByMissionIds(missionIds: List<UUID>)
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
@@ -9,6 +9,7 @@ import com.stack.knowledge.domain.time.domain.Time
 import com.stack.knowledge.domain.time.persistence.mapper.TimeMapper
 import com.stack.knowledge.domain.time.persistence.repository.TimeJpaRepository
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class TimePersistenceAdapter(
@@ -19,6 +20,10 @@ class TimePersistenceAdapter(
 ) : TimePort {
     override fun save(time: Time) {
         timeJpaRepository.save(timeMapper.toEntity(time))
+    }
+
+    override fun deleteAllByMissionIds(missionIds: List<UUID>) {
+        timeJpaRepository.deleteAllByMissionJpaEntities(missionIds)
     }
 
     override fun queryTimeByMissionAndStudentId(mission: Mission, student: Student): Time? =

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/TimePersistenceAdapter.kt
@@ -23,9 +23,9 @@ class TimePersistenceAdapter(
     }
 
     override fun deleteAllByMissionIds(missionIds: List<UUID>) {
-        timeJpaRepository.deleteAllByMissionJpaEntities(missionIds)
+        timeJpaRepository.deleteAllByMissionIds(missionIds)
     }
 
     override fun queryTimeByMissionAndStudentId(mission: Mission, student: Student): Time? =
-        timeMapper.toDomain(timeJpaRepository.findByMissionJpaEntityAndStudentJpaEntity(missionMapper.toEntity(mission), studentMapper.toEntity(student)))
+        timeMapper.toDomain(timeJpaRepository.findByMissionAndStudent(missionMapper.toEntity(mission), studentMapper.toEntity(student)))
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/entity/TimeJpaEntity.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/entity/TimeJpaEntity.kt
@@ -14,10 +14,10 @@ class TimeJpaEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id")
-    val studentJpaEntity: StudentJpaEntity,
+    val student: StudentJpaEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")
-    val missionJpaEntity: MissionJpaEntity
+    val mission: MissionJpaEntity
 
 ) : BaseIdEntity(id)

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/mapper/TimeMapper.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/mapper/TimeMapper.kt
@@ -19,8 +19,8 @@ class TimeMapper(
         entity?.let {
             Time(
                 id = it.id,
-                student = it.studentJpaEntity.id,
-                mission = it.missionJpaEntity.id,
+                student = it.student.id,
+                mission = it.mission.id,
                 createdAt = entity.createdAt
             )
         }
@@ -31,8 +31,8 @@ class TimeMapper(
 
         return TimeJpaEntity(
             id = domain.id,
-            studentJpaEntity = student,
-            missionJpaEntity = mission,
+            student = student,
+            mission = mission,
         )
     }
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
@@ -3,9 +3,14 @@ package com.stack.knowledge.domain.time.persistence.repository
 import com.stack.knowledge.domain.mission.persistence.entity.MissionJpaEntity
 import com.stack.knowledge.domain.student.persistence.entity.StudentJpaEntity
 import com.stack.knowledge.domain.time.persistence.entity.TimeJpaEntity
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface TimeJpaRepository : CrudRepository<TimeJpaEntity, UUID> {
     fun findByMissionJpaEntityAndStudentJpaEntity(missionJpaEntity: MissionJpaEntity, studentJpaEntity: StudentJpaEntity): TimeJpaEntity?
+    @Modifying
+    @Query("delete from TimeJpaEntity t where t.missionJpaEntity in :missionIds")
+    fun deleteAllByMissionJpaEntities(missionIds: List<UUID>)
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/time/persistence/repository/TimeJpaRepository.kt
@@ -9,8 +9,8 @@ import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface TimeJpaRepository : CrudRepository<TimeJpaEntity, UUID> {
-    fun findByMissionJpaEntityAndStudentJpaEntity(missionJpaEntity: MissionJpaEntity, studentJpaEntity: StudentJpaEntity): TimeJpaEntity?
+    fun findByMissionAndStudent(mission: MissionJpaEntity, student: StudentJpaEntity): TimeJpaEntity?
     @Modifying
-    @Query("delete from TimeJpaEntity t where t.missionJpaEntity in :missionIds")
-    fun deleteAllByMissionJpaEntities(missionIds: List<UUID>)
+    @Query("delete from TimeJpaEntity t where t.mission in :missionIds")
+    fun deleteAllByMissionIds(missionIds: List<UUID>)
 }


### PR DESCRIPTION
## 💡 개요
스케줄러 Point, Time 삭제 로직 추가
## 📃 작업내용
Mission이 CLOSED 상태가 되면 더 이상 point와 time은 필요가 없어져 스케줄러에 삭제 로직을 추가해주었습니다.
`kotlin("plugin.jpa") version "1.6.21"`부분에서 이미 추가된 noArgs와  allOpen을 삭제해주었습니다.
모든 부분에서 `??JpaEntity` 로 사용하던 작명을 그냥 `??`으로 바꾸어주었습니다.
