### PR TITLE
# 141 로그아웃 기능 구현

### DIFF
--- a/src/main/kotlin/com/stack/knowledge/domain/auth/application/spi/QueryRefreshTokenPort.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/application/spi/QueryRefreshTokenPort.kt
@@ -3,5 +3,5 @@ package com.stack.knowledge.domain.auth.application.spi
 import com.stack.knowledge.domain.auth.domain.RefreshToken
 
 interface QueryRefreshTokenPort {
-    fun queryByRefreshToken(refreshToken: String): RefreshToken?
+    fun queryById(refreshToken: String): RefreshToken?
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/LogoutUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/LogoutUseCase.kt
@@ -1,0 +1,24 @@
+package com.stack.knowledge.domain.auth.application.usecase
+
+import com.stack.knowledge.common.annotation.usecase.UseCase
+import com.stack.knowledge.common.service.SecurityService
+import com.stack.knowledge.domain.auth.application.spi.RefreshTokenPort
+import com.stack.knowledge.domain.auth.exception.RefreshTokenNotFoundException
+import com.stack.knowledge.domain.user.exception.UserNotFoundException
+
+@UseCase
+class LogoutUseCase(
+    private val refreshTokenPort: RefreshTokenPort,
+    private val securityService: SecurityService
+) {
+    fun execute(refreshToken: String) {
+        val userId = securityService.queryCurrentUserId()
+
+        val token = refreshTokenPort.queryById(refreshToken) ?: throw RefreshTokenNotFoundException()
+
+        if (userId != token.userId)
+            throw UserNotFoundException()
+
+        refreshTokenPort.deleteRefreshTokenById(refreshToken)
+    }
+}

--- a/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/application/usecase/ReissueTokenUseCase.kt
@@ -16,7 +16,7 @@ class ReissueTokenUseCase(
 ) {
     fun execute(requestToken: String): TokenResponse {
         val refreshToken = jwtParserPort.parseRefreshToken(requestToken) ?: throw InvalidRefreshTokenException()
-        val token = refreshTokenPort.queryByRefreshToken(refreshToken) ?: throw RefreshTokenNotFoundException()
+        val token = refreshTokenPort.queryById(refreshToken) ?: throw RefreshTokenNotFoundException()
         refreshTokenPort.deleteRefreshTokenById(refreshToken)
 
         return jwtGeneratorPort.receiveToken(token.userId, token.authority)

--- a/src/main/kotlin/com/stack/knowledge/domain/auth/persistence/RefreshTokenPersistenceAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/persistence/RefreshTokenPersistenceAdapter.kt
@@ -21,6 +21,6 @@ class RefreshTokenPersistenceAdapter(
         refreshTokenRepository.deleteById(refreshToken)
     }
 
-    override fun queryByRefreshToken(refreshToken: String): RefreshToken? =
+    override fun queryById(refreshToken: String): RefreshToken? =
         refreshTokenMapper.toDomain(refreshTokenRepository.findByIdOrNull(refreshToken))
 }

--- a/src/main/kotlin/com/stack/knowledge/domain/auth/presentation/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/stack/knowledge/domain/auth/presentation/AuthWebAdapter.kt
@@ -1,6 +1,7 @@
 package com.stack.knowledge.domain.auth.presentation
 
 import com.stack.knowledge.domain.auth.application.usecase.GAuthSignInUseCase
+import com.stack.knowledge.domain.auth.application.usecase.LogoutUseCase
 import com.stack.knowledge.domain.auth.application.usecase.ReissueTokenUseCase
 import com.stack.knowledge.domain.auth.presentation.data.request.GAuthSignInRequest
 import com.stack.knowledge.domain.auth.presentation.data.response.TokenResponse
@@ -12,7 +13,8 @@ import javax.validation.Valid
 @RequestMapping("/auth")
 class AuthWebAdapter(
     private val gAuthSignInUseCase: GAuthSignInUseCase,
-    private val reissueTokenUseCase: ReissueTokenUseCase
+    private val reissueTokenUseCase: ReissueTokenUseCase,
+    private val logoutUseCase: LogoutUseCase
 ) {
     @PostMapping
     fun signIn(@RequestBody @Valid gAuthSignInRequest: GAuthSignInRequest): ResponseEntity<TokenResponse> =
@@ -23,4 +25,9 @@ class AuthWebAdapter(
     fun reissueToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<TokenResponse> =
         reissueTokenUseCase.execute(refreshToken)
             .let { ResponseEntity.ok(it) }
+
+    @DeleteMapping
+    fun logout(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<Valid> =
+        logoutUseCase.execute(refreshToken)
+            .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/stack/knowledge/global/security/SecurityConfig.kt
@@ -46,6 +46,7 @@ class SecurityConfig(
             // auth
             .antMatchers(HttpMethod.POST, "/auth").permitAll()
             .antMatchers(HttpMethod.PATCH, "/auth").permitAll()
+            .antMatchers(HttpMethod.DELETE, "/auth").authenticated()
 
             // item
             .antMatchers(HttpMethod.GET , "/item").hasRole(student)


### PR DESCRIPTION
## 💡 개요
로그아웃 기능 구현
## 📃 작업내용
refreshToken 을 db에서 삭제하는 방식으로 구현하였습니다.
access token 을 black list 에 등록하여 사용하지 못하도록 해도 되지만 token 만료 기간이 짧고 black list 에 등록하게 되면 세션 기반 인증을 사용하는 것과 별 차이가 없기 때문에 이렇게 구현하였습니다.
